### PR TITLE
Add Viscovery demo WPF POS solution

### DIFF
--- a/ViscoveryDemoPOS.BLL/RecognitionComparer.cs
+++ b/ViscoveryDemoPOS.BLL/RecognitionComparer.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using System.Linq;
+using ViscoveryDemoPOS.Domain;
+
+namespace ViscoveryDemoPOS.BLL
+{
+    public static class RecognitionComparer
+    {
+        public static List<ProductItem> MergeAndMark(QrOrder order, IEnumerable<ProductItem> recognized)
+        {
+            var result = order.ExpectedItems.Select(x => new ProductItem
+            {
+                Code = x.Code, Name = x.Name, Price = x.Price, Status = RecognizeStatus.Undetected
+            }).ToList();
+
+            foreach (var r in recognized)
+            {
+                var match = result.FirstOrDefault(i => i.Code == r.Code || i.Name == r.Name);
+                if (match != null) match.Status = RecognizeStatus.Confirm;
+                else result.Add(new ProductItem { Code = r.Code, Name = r.Name, Status = RecognizeStatus.Extra });
+            }
+
+            return result;
+        }
+    }
+}

--- a/ViscoveryDemoPOS.BLL/ViscoveryDemoPOS.BLL.csproj
+++ b/ViscoveryDemoPOS.BLL/ViscoveryDemoPOS.BLL.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net461</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ViscoveryDemoPOS.Domain\ViscoveryDemoPOS.Domain.csproj" />
+  </ItemGroup>
+</Project>

--- a/ViscoveryDemoPOS.DAL/IRecognitionLogRepository.cs
+++ b/ViscoveryDemoPOS.DAL/IRecognitionLogRepository.cs
@@ -1,0 +1,9 @@
+using ViscoveryDemoPOS.Domain;
+
+namespace ViscoveryDemoPOS.DAL
+{
+    public interface IRecognitionLogRepository
+    {
+        void Log(string orderId, ProductItem item);
+    }
+}

--- a/ViscoveryDemoPOS.DAL/RecognitionLogRepository.cs
+++ b/ViscoveryDemoPOS.DAL/RecognitionLogRepository.cs
@@ -1,0 +1,26 @@
+using System;
+using System.IO;
+using ViscoveryDemoPOS.Domain;
+
+namespace ViscoveryDemoPOS.DAL
+{
+    public class RecognitionLogRepository : IRecognitionLogRepository
+    {
+        private readonly string _file;
+
+        public RecognitionLogRepository(string file = "recognition_log.csv")
+        {
+            _file = file;
+            if (!File.Exists(_file))
+            {
+                File.WriteAllText(_file, "Time,OrderId,Code,Name,Status\n");
+            }
+        }
+
+        public void Log(string orderId, ProductItem item)
+        {
+            var line = string.Format("{0},{1},{2},{3},{4}\n", DateTime.UtcNow.ToString("o"), orderId, item.Code, item.Name, item.Status);
+            File.AppendAllText(_file, line);
+        }
+    }
+}

--- a/ViscoveryDemoPOS.DAL/ViscoveryDemoPOS.DAL.csproj
+++ b/ViscoveryDemoPOS.DAL/ViscoveryDemoPOS.DAL.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net461</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ViscoveryDemoPOS.Domain\ViscoveryDemoPOS.Domain.csproj" />
+  </ItemGroup>
+</Project>

--- a/ViscoveryDemoPOS.Domain/Products.cs
+++ b/ViscoveryDemoPOS.Domain/Products.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+
+namespace ViscoveryDemoPOS.Domain
+{
+    public enum RecognizeStatus { Waiting, Confirm, Undetected, Extra }
+
+    public class ProductItem
+    {
+        public string Code { get; set; }
+        public string Name { get; set; }
+        public decimal Price { get; set; }
+        public RecognizeStatus Status { get; set; }
+    }
+
+    public class QrOrder
+    {
+        public string OrderId { get; set; }
+        public List<ProductItem> ExpectedItems { get; set; } = new List<ProductItem>();
+    }
+}

--- a/ViscoveryDemoPOS.Domain/VisAgentDtos.cs
+++ b/ViscoveryDemoPOS.Domain/VisAgentDtos.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+
+namespace ViscoveryDemoPOS.Domain
+{
+    public class UnifiedRecognitionResponse
+    {
+        public int code { get; set; }
+        public string message { get; set; }
+        public UnifiedData data { get; set; }
+    }
+
+    public class UnifiedData
+    {
+        public UnifiedOrder order { get; set; }
+    }
+
+    public class UnifiedOrder
+    {
+        public List<Plate> plates { get; set; }
+    }
+
+    public class Plate
+    {
+        public List<Instance> instances { get; set; }
+    }
+
+    public class Instance
+    {
+        public Product product { get; set; }
+    }
+
+    public class Product
+    {
+        public string product_code { get; set; }
+        public string product_name { get; set; }
+    }
+
+    public class CheckoutItem
+    {
+        public string product_code { get; set; }
+        public string product_name { get; set; }
+        public List<CheckoutItem> combo_data { get; set; }
+    }
+}

--- a/ViscoveryDemoPOS.Domain/ViscoveryDemoPOS.Domain.csproj
+++ b/ViscoveryDemoPOS.Domain/ViscoveryDemoPOS.Domain.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net461</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
+</Project>

--- a/ViscoveryDemoPOS.Presentation/App.xaml
+++ b/ViscoveryDemoPOS.Presentation/App.xaml
@@ -1,0 +1,7 @@
+<Application x:Class="ViscoveryDemoPOS.Presentation.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             StartupUri="MainWindow.xaml">
+    <Application.Resources>
+    </Application.Resources>
+</Application>

--- a/ViscoveryDemoPOS.Presentation/App.xaml.cs
+++ b/ViscoveryDemoPOS.Presentation/App.xaml.cs
@@ -1,0 +1,8 @@
+using System.Windows;
+
+namespace ViscoveryDemoPOS.Presentation
+{
+    public partial class App : Application
+    {
+    }
+}

--- a/ViscoveryDemoPOS.Presentation/Converters/BoolToBrushConverter.cs
+++ b/ViscoveryDemoPOS.Presentation/Converters/BoolToBrushConverter.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Globalization;
+using System.Windows.Data;
+using System.Windows.Media;
+
+namespace ViscoveryDemoPOS.Presentation.Converters
+{
+    public class BoolToBrushConverter : IValueConverter
+    {
+        public Brush TrueBrush { get; set; } = Brushes.Green;
+        public Brush FalseBrush { get; set; } = Brushes.Red;
+
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is bool b)
+                return b ? TrueBrush : FalseBrush;
+            return FalseBrush;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/ViscoveryDemoPOS.Presentation/Converters/InverseBoolToVisibilityConverter.cs
+++ b/ViscoveryDemoPOS.Presentation/Converters/InverseBoolToVisibilityConverter.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace ViscoveryDemoPOS.Presentation.Converters
+{
+    public class InverseBoolToVisibilityConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is bool b)
+                return b ? Visibility.Collapsed : Visibility.Visible;
+            return Visibility.Visible;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/ViscoveryDemoPOS.Presentation/Converters/StringToVisibilityConverter.cs
+++ b/ViscoveryDemoPOS.Presentation/Converters/StringToVisibilityConverter.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace ViscoveryDemoPOS.Presentation.Converters
+{
+    public class StringToVisibilityConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            var str = value as string;
+            return string.IsNullOrWhiteSpace(str) ? Visibility.Collapsed : Visibility.Visible;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/ViscoveryDemoPOS.Presentation/MainWindow.xaml
+++ b/ViscoveryDemoPOS.Presentation/MainWindow.xaml
@@ -1,0 +1,36 @@
+<Window x:Class="ViscoveryDemoPOS.Presentation.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="clr-namespace:ViscoveryDemoPOS.ViewModels"
+        xmlns:views="clr-namespace:ViscoveryDemoPOS.Presentation.Views"
+        xmlns:conv="clr-namespace:ViscoveryDemoPOS.Presentation.Converters"
+        Title="Viscovery Demo AP" Width="1280" Height="800" WindowStartupLocation="CenterScreen">
+    <Window.DataContext>
+        <vm:MainViewModel/>
+    </Window.DataContext>
+    <Window.Resources>
+        <BooleanToVisibilityConverter x:Key="BoolToVisibilityConverter" />
+        <conv:InverseBoolToVisibilityConverter x:Key="InverseBoolToVisibilityConverter" />
+        <conv:BoolToBrushConverter x:Key="BoolToBrushConverter" />
+        <conv:StringToVisibilityConverter x:Key="StringToVisibilityConverter" />
+    </Window.Resources>
+    <Grid Background="#0f172a">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="60"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="40"/>
+        </Grid.RowDefinitions>
+        <DockPanel Grid.Row="0" Margin="16,0" VerticalAlignment="Center">
+            <TextBlock Text="prox" Foreground="White" FontSize="24" FontWeight="Bold" VerticalAlignment="Center"/>
+            <TextBlock Text="Viscovery Demo AP" Foreground="White" FontSize="20" Margin="12,0,0,0" VerticalAlignment="Center"/>
+        </DockPanel>
+
+        <views:HomeView Grid.Row="1" Visibility="{Binding IsHome, Converter={StaticResource BoolToVisibilityConverter}}"/>
+        <views:MainPage Grid.Row="1" Visibility="{Binding IsHome, Converter={StaticResource InverseBoolToVisibilityConverter}}"/>
+
+        <Border Grid.Row="2" Background="{Binding IsSuccessBanner, Converter={StaticResource BoolToBrushConverter}}"
+                Visibility="{Binding BannerMessage, Converter={StaticResource StringToVisibilityConverter}}">
+            <TextBlock Text="{Binding BannerMessage}" Foreground="White" VerticalAlignment="Center" HorizontalAlignment="Center"/>
+        </Border>
+    </Grid>
+</Window>

--- a/ViscoveryDemoPOS.Presentation/MainWindow.xaml.cs
+++ b/ViscoveryDemoPOS.Presentation/MainWindow.xaml.cs
@@ -1,0 +1,12 @@
+using System.Windows;
+
+namespace ViscoveryDemoPOS.Presentation
+{
+    public partial class MainWindow : Window
+    {
+        public MainWindow()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/ViscoveryDemoPOS.Presentation/Views/HomeView.xaml
+++ b/ViscoveryDemoPOS.Presentation/Views/HomeView.xaml
@@ -1,0 +1,11 @@
+<UserControl x:Class="ViscoveryDemoPOS.Presentation.Views.HomeView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Grid Background="#0f172a">
+        <DockPanel Margin="16,16,0,0" HorizontalAlignment="Left" VerticalAlignment="Top">
+            <TextBlock Text="prox" Foreground="White" FontSize="24" FontWeight="Bold"/>
+        </DockPanel>
+        <Button Content="Start Scanning" Command="{Binding StartScanningCommand}" Width="200" Height="80"
+                HorizontalAlignment="Center" VerticalAlignment="Center"/>
+    </Grid>
+</UserControl>

--- a/ViscoveryDemoPOS.Presentation/Views/HomeView.xaml.cs
+++ b/ViscoveryDemoPOS.Presentation/Views/HomeView.xaml.cs
@@ -1,0 +1,12 @@
+using System.Windows.Controls;
+
+namespace ViscoveryDemoPOS.Presentation.Views
+{
+    public partial class HomeView : UserControl
+    {
+        public HomeView()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/ViscoveryDemoPOS.Presentation/Views/MainPage.xaml
+++ b/ViscoveryDemoPOS.Presentation/Views/MainPage.xaml
@@ -1,0 +1,27 @@
+<UserControl x:Class="ViscoveryDemoPOS.Presentation.Views.MainPage"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Grid Margin="16">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="3*"/>
+            <ColumnDefinition Width="2*"/>
+        </Grid.ColumnDefinitions>
+
+        <DataGrid Grid.Column="0" ItemsSource="{Binding Items}" AutoGenerateColumns="False" HeadersVisibility="Column"
+                  Background="#111827" Foreground="White" RowBackground="#1f2937" AlternatingRowBackground="#111827">
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="品名" Binding="{Binding Name}" Width="*"/>
+                <DataGridTextColumn Header="代碼" Binding="{Binding Code}" Width="120"/>
+                <DataGridTextColumn Header="價格" Binding="{Binding Price}" Width="100"/>
+                <DataGridTextColumn Header="狀態" Binding="{Binding Status}" Width="120"/>
+            </DataGrid.Columns>
+        </DataGrid>
+
+        <StackPanel Grid.Column="1" Margin="16" VerticalAlignment="Top">
+            <Button Content="初始化 (Health + Config)" Command="{Binding InitCommand}" Height="44" Margin="0,0,0,8"/>
+            <Button Content="取得 QRCode" Command="{Binding GetQrCodeCommand}" Height="44" Margin="0,0,0,8"/>
+            <Button Content="啟用 Viscovery" Command="{Binding StartViscoveryCommand}" Height="44" Margin="0,0,0,8"/>
+            <Button Content="重置" Command="{Binding ResetCommand}" Height="44"/>
+        </StackPanel>
+    </Grid>
+</UserControl>

--- a/ViscoveryDemoPOS.Presentation/Views/MainPage.xaml.cs
+++ b/ViscoveryDemoPOS.Presentation/Views/MainPage.xaml.cs
@@ -1,0 +1,12 @@
+using System.Windows.Controls;
+
+namespace ViscoveryDemoPOS.Presentation.Views
+{
+    public partial class MainPage : UserControl
+    {
+        public MainPage()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/ViscoveryDemoPOS.Presentation/ViscoveryDemoPOS.Presentation.csproj
+++ b/ViscoveryDemoPOS.Presentation/ViscoveryDemoPOS.Presentation.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net461</TargetFramework>
+    <UseWPF>true</UseWPF>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ViscoveryDemoPOS.ViewModels\ViscoveryDemoPOS.ViewModels.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="MvvmLightLibs" Version="5.4.1.1" />
+  </ItemGroup>
+</Project>

--- a/ViscoveryDemoPOS.Services/PosCallbackServer.cs
+++ b/ViscoveryDemoPOS.Services/PosCallbackServer.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Net;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using System.Collections.Generic;
+using ViscoveryDemoPOS.Domain;
+
+namespace ViscoveryDemoPOS.Services
+{
+    public class PosCallbackServer : IDisposable
+    {
+        private readonly HttpListener _listener = new HttpListener();
+        private CancellationTokenSource _cts;
+        public event Action<List<CheckoutItem>> OnCheckoutReceived;
+
+        public PosCallbackServer(string prefix = "http://127.0.0.1:8080/visagent/")
+        {
+            _listener.Prefixes.Add(prefix);
+        }
+
+        public void Start()
+        {
+            if (_listener.IsListening) return;
+            _cts = new CancellationTokenSource();
+            _listener.Start();
+            Task.Run(() => LoopAsync(_cts.Token));
+        }
+
+        private async Task LoopAsync(CancellationToken token)
+        {
+            while (!token.IsCancellationRequested)
+            {
+                var ctx = await _listener.GetContextAsync().ConfigureAwait(false);
+                if (ctx.Request.HttpMethod == "POST" && ctx.Request.Url.AbsolutePath.EndsWith("/checkout", StringComparison.OrdinalIgnoreCase))
+                {
+                    string body;
+                    using (var sr = new System.IO.StreamReader(ctx.Request.InputStream, ctx.Request.ContentEncoding))
+                        body = sr.ReadToEnd();
+
+                    var items = JsonConvert.DeserializeObject<List<CheckoutItem>>(body);
+                    OnCheckoutReceived?.Invoke(items);
+
+                    var buffer = Encoding.UTF8.GetBytes("{\"status\":\"ok\"}");
+                    ctx.Response.StatusCode = 200;
+                    ctx.Response.ContentType = "application/json";
+                    ctx.Response.OutputStream.Write(buffer, 0, buffer.Length);
+                    ctx.Response.Close();
+                }
+                else
+                {
+                    ctx.Response.StatusCode = 404;
+                    ctx.Response.Close();
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            try { _cts?.Cancel(); } catch { }
+            try { _listener?.Stop(); } catch { }
+            try { _listener?.Close(); } catch { }
+        }
+    }
+}

--- a/ViscoveryDemoPOS.Services/VisAgentApiClient.cs
+++ b/ViscoveryDemoPOS.Services/VisAgentApiClient.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using ViscoveryDemoPOS.Domain;
+using System.Collections.Generic;
+
+namespace ViscoveryDemoPOS.Services
+{
+    public class VisAgentApiClient
+    {
+        private readonly HttpClient _http;
+        private readonly string _base = "http://127.0.0.1:1688";
+
+        public VisAgentApiClient(HttpClient httpClient = null)
+        {
+            _http = httpClient ?? new HttpClient();
+        }
+
+        public async Task<bool> HealthAsync()
+        {
+            var url = _base + "/api/v2/health";
+            var res = await _http.GetAsync(url).ConfigureAwait(false);
+            return res.IsSuccessStatusCode;
+        }
+
+        public async Task ConfigureAsync(string posUrlOrigin = "http://127.0.0.1:8080")
+        {
+            var url = _base + "/api/v1/config";
+            var payload = new
+            {
+                OutputModeInfo = new
+                {
+                    POSUrlOrigin = posUrlOrigin,
+                    ExternalOutputDelay = 0.25,
+                    CursorClickX = -1,
+                    CursorClickY = -1
+                },
+                GuiInfo = new
+                {
+                    DisplayFrameType = "bbox",
+                    Language = "zh-TW"
+                }
+            };
+            var json = JsonConvert.SerializeObject(payload);
+            var res = await _http.PostAsync(url, new StringContent(json, Encoding.UTF8, "application/json")).ConfigureAwait(false);
+            res.EnsureSuccessStatusCode();
+        }
+
+        public async Task<UnifiedRecognitionResponse> UnifiedRecognitionAsync(bool switchToVisAgent = true, string[] responseFields = null)
+        {
+            var url = _base + "/api/v1/unified_recognition";
+            var payload = new Dictionary<string, object>();
+            payload["switch_to_visagent"] = switchToVisAgent;
+            if (responseFields != null && responseFields.Length > 0)
+                payload["response_fields"] = responseFields;
+
+            var json = JsonConvert.SerializeObject(payload);
+            var res = await _http.PostAsync(url, new StringContent(json, Encoding.UTF8, "application/json")).ConfigureAwait(false);
+            var body = await res.Content.ReadAsStringAsync().ConfigureAwait(false);
+            return JsonConvert.DeserializeObject<UnifiedRecognitionResponse>(body);
+        }
+
+        public async Task SwitchPageAsync(string page, object parameter = null)
+        {
+            var url = _base + "/api/v2/switch";
+            var payload = new { page = page, parameter = parameter };
+            var json = JsonConvert.SerializeObject(payload);
+            var res = await _http.PostAsync(url, new StringContent(json, Encoding.UTF8, "application/json")).ConfigureAwait(false);
+            res.EnsureSuccessStatusCode();
+        }
+    }
+}

--- a/ViscoveryDemoPOS.Services/ViscoveryDemoPOS.Services.csproj
+++ b/ViscoveryDemoPOS.Services/ViscoveryDemoPOS.Services.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net461</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ViscoveryDemoPOS.Domain\ViscoveryDemoPOS.Domain.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
+</Project>

--- a/ViscoveryDemoPOS.ViewModels/MainViewModel.cs
+++ b/ViscoveryDemoPOS.ViewModels/MainViewModel.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using GalaSoft.MvvmLight;
+using GalaSoft.MvvmLight.Command;
+using ViscoveryDemoPOS.Domain;
+using ViscoveryDemoPOS.Services;
+using ViscoveryDemoPOS.BLL;
+using ViscoveryDemoPOS.DAL;
+
+namespace ViscoveryDemoPOS.ViewModels
+{
+    public class MainViewModel : ViewModelBase
+    {
+        private readonly VisAgentApiClient _api;
+        private readonly PosCallbackServer _server;
+        private readonly IRecognitionLogRepository _logRepo;
+        public ObservableCollection<ProductItem> Items { get; } = new ObservableCollection<ProductItem>();
+        public string BannerMessage { get; set; }
+        public bool IsSuccessBanner { get; set; }
+
+        public bool IsHome { get; set; } = true;
+
+        public ICommand InitCommand { get; private set; }
+        public ICommand GetQrCodeCommand { get; private set; }
+        public ICommand StartViscoveryCommand { get; private set; }
+        public ICommand ResetCommand { get; private set; }
+        public ICommand StartScanningCommand { get; private set; }
+
+        private QrOrder _currentOrder;
+
+        public MainViewModel()
+        {
+            _api = new VisAgentApiClient();
+            _server = new PosCallbackServer();
+            _logRepo = new RecognitionLogRepository();
+            _server.OnCheckoutReceived += OnCheckout;
+
+            InitCommand = new RelayCommand(async _ => await InitAsync());
+            GetQrCodeCommand = new RelayCommand(_ => LoadDemoQr());
+            StartViscoveryCommand = new RelayCommand(async _ => await StartViscoveryAsync(), _ => _currentOrder != null);
+            ResetCommand = new RelayCommand(_ => Reset());
+            StartScanningCommand = new RelayCommand(_ => { IsHome = false; RaisePropertyChanged(nameof(IsHome)); });
+        }
+
+        private async Task InitAsync()
+        {
+            _server.Start();
+            var ok = await _api.HealthAsync();
+            if (!ok)
+            {
+                BannerMessage = "VisAgent 未就緒";
+                IsSuccessBanner = false;
+                RaisePropertyChanged(nameof(BannerMessage));
+                RaisePropertyChanged(nameof(IsSuccessBanner));
+                return;
+            }
+            await _api.ConfigureAsync("http://127.0.0.1:8080");
+        }
+
+        private void LoadDemoQr()
+        {
+            _currentOrder = new QrOrder
+            {
+                OrderId = Guid.NewGuid().ToString("N"),
+                ExpectedItems =
+                {
+                    new ProductItem { Code = "1111", Name = "華堡", Status = RecognizeStatus.Waiting },
+                    new ProductItem { Code = "2222", Name = "牛肉堡", Status = RecognizeStatus.Waiting }
+                }
+            };
+            RefreshGrid(_currentOrder.ExpectedItems);
+        }
+
+        private async Task StartViscoveryAsync()
+        {
+            BannerMessage = "啟動影像辨識...";
+            RaisePropertyChanged(nameof(BannerMessage));
+            await _api.UnifiedRecognitionAsync(true, null);
+        }
+
+        private void OnCheckout(System.Collections.Generic.List<CheckoutItem> items)
+        {
+            var recognized = items
+                .Select(i => new ProductItem { Code = i.product_code, Name = i.product_name, Status = RecognizeStatus.Confirm })
+                .ToList();
+
+            var merged = RecognitionComparer.MergeAndMark(_currentOrder, recognized);
+            RefreshGrid(merged);
+
+            foreach (var it in merged)
+            {
+                _logRepo.Log(_currentOrder.OrderId, it);
+            }
+
+            IsSuccessBanner = merged.All(p => p.Status == RecognizeStatus.Confirm);
+            BannerMessage = IsSuccessBanner ? "成功掃描" : "掃描錯誤";
+            RaisePropertyChanged(nameof(BannerMessage));
+            RaisePropertyChanged(nameof(IsSuccessBanner));
+        }
+
+        private void RefreshGrid(System.Collections.Generic.IEnumerable<ProductItem> list)
+        {
+            Items.Clear();
+            foreach (var it in list) Items.Add(it);
+            RaisePropertyChanged(nameof(Items));
+        }
+
+        private void Reset()
+        {
+            _currentOrder = null;
+            Items.Clear();
+            BannerMessage = string.Empty;
+            IsHome = true;
+            RaisePropertyChanged(nameof(BannerMessage));
+            RaisePropertyChanged(nameof(IsHome));
+        }
+    }
+}

--- a/ViscoveryDemoPOS.ViewModels/ViscoveryDemoPOS.ViewModels.csproj
+++ b/ViscoveryDemoPOS.ViewModels/ViscoveryDemoPOS.ViewModels.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net461</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ViscoveryDemoPOS.Domain\ViscoveryDemoPOS.Domain.csproj" />
+    <ProjectReference Include="..\ViscoveryDemoPOS.Services\ViscoveryDemoPOS.Services.csproj" />
+    <ProjectReference Include="..\ViscoveryDemoPOS.BLL\ViscoveryDemoPOS.BLL.csproj" />
+    <ProjectReference Include="..\ViscoveryDemoPOS.DAL\ViscoveryDemoPOS.DAL.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="MvvmLightLibs" Version="5.4.1.1" />
+  </ItemGroup>
+</Project>

--- a/ViscoveryDemoPOS.sln
+++ b/ViscoveryDemoPOS.sln
@@ -1,0 +1,51 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ViscoveryDemoPOS.Presentation", "ViscoveryDemoPOS.Presentation\ViscoveryDemoPOS.Presentation.csproj", "{5DCDDD21-28D5-47A7-90FB-CF5BDF1D6CC5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ViscoveryDemoPOS.ViewModels", "ViscoveryDemoPOS.ViewModels\ViscoveryDemoPOS.ViewModels.csproj", "{D192E554-2EC4-4626-83F0-7FC1562BEA56}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ViscoveryDemoPOS.BLL", "ViscoveryDemoPOS.BLL\ViscoveryDemoPOS.BLL.csproj", "{F9FB09AD-4DAC-4F9B-A0AB-BAEF7E03B134}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ViscoveryDemoPOS.DAL", "ViscoveryDemoPOS.DAL\ViscoveryDemoPOS.DAL.csproj", "{6AC6087B-93D4-4238-964D-DCC606063A9F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ViscoveryDemoPOS.Services", "ViscoveryDemoPOS.Services\ViscoveryDemoPOS.Services.csproj", "{81E2D725-CDFA-423D-9876-5334563B02A7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ViscoveryDemoPOS.Domain", "ViscoveryDemoPOS.Domain\ViscoveryDemoPOS.Domain.csproj", "{83CA2ED8-9D10-4626-89D4-EAA5FC85D35C}"
+EndProject
+Global
+    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+        Debug|Any CPU = Debug|Any CPU
+        Release|Any CPU = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+        {5DCDDD21-28D5-47A7-90FB-CF5BDF1D6CC5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {5DCDDD21-28D5-47A7-90FB-CF5BDF1D6CC5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {5DCDDD21-28D5-47A7-90FB-CF5BDF1D6CC5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {5DCDDD21-28D5-47A7-90FB-CF5BDF1D6CC5}.Release|Any CPU.Build.0 = Release|Any CPU
+        {D192E554-2EC4-4626-83F0-7FC1562BEA56}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {D192E554-2EC4-4626-83F0-7FC1562BEA56}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {D192E554-2EC4-4626-83F0-7FC1562BEA56}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {D192E554-2EC4-4626-83F0-7FC1562BEA56}.Release|Any CPU.Build.0 = Release|Any CPU
+        {F9FB09AD-4DAC-4F9B-A0AB-BAEF7E03B134}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {F9FB09AD-4DAC-4F9B-A0AB-BAEF7E03B134}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {F9FB09AD-4DAC-4F9B-A0AB-BAEF7E03B134}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {F9FB09AD-4DAC-4F9B-A0AB-BAEF7E03B134}.Release|Any CPU.Build.0 = Release|Any CPU
+        {6AC6087B-93D4-4238-964D-DCC606063A9F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {6AC6087B-93D4-4238-964D-DCC606063A9F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {6AC6087B-93D4-4238-964D-DCC606063A9F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {6AC6087B-93D4-4238-964D-DCC606063A9F}.Release|Any CPU.Build.0 = Release|Any CPU
+        {81E2D725-CDFA-423D-9876-5334563B02A7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {81E2D725-CDFA-423D-9876-5334563B02A7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {81E2D725-CDFA-423D-9876-5334563B02A7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {81E2D725-CDFA-423D-9876-5334563B02A7}.Release|Any CPU.Build.0 = Release|Any CPU
+        {83CA2ED8-9D10-4626-89D4-EAA5FC85D35C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {83CA2ED8-9D10-4626-89D4-EAA5FC85D35C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {83CA2ED8-9D10-4626-89D4-EAA5FC85D35C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {83CA2ED8-9D10-4626-89D4-EAA5FC85D35C}.Release|Any CPU.Build.0 = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(SolutionProperties) = preSolution
+        HideSolutionNode = FALSE
+    EndGlobalSection
+EndGlobal


### PR DESCRIPTION
## Summary
- Add multi-project .NET Framework 4.6.1 solution `ViscoveryDemoPOS`
- Implement domain models, service API client, callback server, BLL comparer, DAL logging, and MVVM ViewModel
- Create WPF presentation layer with home and main pages, converters, and assets
- Replace binary logo with text placeholder to avoid unsupported files

## Testing
- `dotnet build ViscoveryDemoPOS.sln` *(fails: command not found)*
- `msbuild ViscoveryDemoPOS.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae7b9739c88326a3fd05857b0449fe