### PR TITLE
fix: correct RelayCommand usage

### DIFF
--- a/ViscoveryDemoPOS.ViewModels/MainViewModel.cs
+++ b/ViscoveryDemoPOS.ViewModels/MainViewModel.cs
@@ -38,11 +38,11 @@ namespace ViscoveryDemoPOS.ViewModels
             _logRepo = new RecognitionLogRepository();
             _server.OnCheckoutReceived += OnCheckout;
 
-            InitCommand = new RelayCommand(async _ => await InitAsync());
-            GetQrCodeCommand = new RelayCommand(_ => LoadDemoQr());
-            StartViscoveryCommand = new RelayCommand(async _ => await StartViscoveryAsync(), _ => _currentOrder != null);
-            ResetCommand = new RelayCommand(_ => Reset());
-            StartScanningCommand = new RelayCommand(_ => { IsHome = false; RaisePropertyChanged(nameof(IsHome)); });
+            InitCommand = new RelayCommand(async () => await InitAsync());
+            GetQrCodeCommand = new RelayCommand(() => LoadDemoQr());
+            StartViscoveryCommand = new RelayCommand(async () => await StartViscoveryAsync(), () => _currentOrder != null);
+            ResetCommand = new RelayCommand(() => Reset());
+            StartScanningCommand = new RelayCommand(() => { IsHome = false; RaisePropertyChanged(nameof(IsHome)); });
         }
 
         private async Task InitAsync()


### PR DESCRIPTION
## Summary
- fix delegate argument mismatch in MainViewModel commands

## Testing
- `dotnet build ViscoveryDemoPOS.sln` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68ae9971d7c883269059fd4ff597744e